### PR TITLE
Added 'X-Clockwork-Path' header check

### DIFF
--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -48,10 +48,11 @@ Clockwork.controller('PanelController', function PanelController($scope, $http)
 			headers = request.response.headers;
 			var requestId = headers.find(function(x) { return x.name == 'X-Clockwork-Id'; });
 			var requestVersion = headers.find(function(x) { return x.name == 'X-Clockwork-Version'; });
+            var requestPath = headers.find(function(x) { return x.name == 'X-Clockwork-Path'; });
 
 			if (requestVersion !== undefined) {
 				var uri = new URI(request.request.url);
-				var path = '/__clockwork/' + requestId.value;
+				var path = ((requestPath) ? requestPath.value : '') + '/__clockwork/' + requestId.value;
 				uri.pathname(path);
 
 				chrome.extension.sendRequest({action: 'getJSON', url: uri.toString()}, function(data){


### PR DESCRIPTION
The X-Clockwork-Path header can change the base URL that Clockwork will
check for request JSON. If present it will be prefixed to the already
standard /__clockwork/{id} URL. For instance passing
/some/directory/path in X-Clockwork-Path will then have the request be
/some/directory/path/__clockwork/{id}.
