### PR TITLE
Fix for "X-Clockwork-Path escapes query part of an URL" issue

### DIFF
--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -53,7 +53,12 @@ Clockwork.controller('PanelController', function PanelController($scope, $http)
 			if (requestVersion !== undefined) {
 				var uri = new URI(request.request.url);
 				var path = ((requestPath) ? requestPath.value : '/__clockwork/') + requestId.value;
-				uri.pathname(path);
+
+				path = path.split('?');
+				uri.pathname(path[0]);
+				if (path[1]) {
+					uri.query(path[1]);
+				}
 
 				chrome.extension.sendRequest({action: 'getJSON', url: uri.toString()}, function(data){
 					$scope.$apply(function(){


### PR DESCRIPTION
Resolves issue raised in #5 ticket.
