### PR TITLE
Show last request when opened

### DIFF
--- a/Clockwork Chrome/assets/javascripts/background.js
+++ b/Clockwork Chrome/assets/javascripts/background.js
@@ -43,7 +43,7 @@ chrome.webRequest.onCompleted.addListener(
 			lastClockworkRequestPerTab[request.tabId] = { url: request.url, headers: request.responseHeaders }
 		}
 	},
-	{ urls: [ '<all_urls>' ] },
+	{ urls: [ '<all_urls>' ], types: [ 'main_frame' ] },
 	[ 'responseHeaders' ]
 )
 

--- a/Clockwork Chrome/assets/javascripts/background.js
+++ b/Clockwork Chrome/assets/javascripts/background.js
@@ -7,7 +7,12 @@ function onMessage(message, sender, callback) {
 		xhr.onreadystatechange = function() {
 			if (xhr.readyState == 4) {
 				if (xhr.status == 200) {
-					callback(JSON.parse(xhr.responseText));
+					try {
+						callback(JSON.parse(xhr.responseText));
+					} catch (e) {
+						console.log('Invalid Clockwork metadata:');
+						console.log(xhr.responseText);
+					}
 				} else {
 					console.log('Error getting Clockwork metadata:');
 					console.log(xhr.responseText);
@@ -15,7 +20,7 @@ function onMessage(message, sender, callback) {
 			}
 		}
 
-		Object.keys(message.headers).forEach(function(headerName) {
+		Object.keys(message.headers || {}).forEach(function(headerName) {
 		    xhr.setRequestHeader(headerName, message.headers[headerName]);
 		});
 

--- a/Clockwork Chrome/assets/javascripts/background.js
+++ b/Clockwork Chrome/assets/javascripts/background.js
@@ -25,9 +25,26 @@ function onMessage(message, sender, callback) {
 		});
 
 		xhr.send();
-
-		return true;
+	} else if (message.action == 'getLastClockworkRequestInTab') {
+		callback(lastClockworkRequestPerTab[message.tabId])
 	}
+
+	return true
 }
 
 chrome.runtime.onMessage.addListener(onMessage);
+
+// track last clockwork-enabled request per tab
+let lastClockworkRequestPerTab = {}
+
+chrome.webRequest.onCompleted.addListener(
+	(request) => {
+		if (request.responseHeaders.find((x) => x.name.toLowerCase() == 'x-clockwork-id')) {
+			lastClockworkRequestPerTab[request.tabId] = { url: request.url, headers: request.responseHeaders }
+		}
+	},
+	{ urls: [ '<all_urls>' ] },
+	[ 'responseHeaders' ]
+)
+
+chrome.tabs.onRemoved.addListener((tabId) => delete lastClockworkRequestPerTab[tabId])

--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -71,14 +71,19 @@ Clockwork.controller('PanelController', function($scope, $http, toolbar)
 
 				chrome.runtime.sendMessage(
 					{ action: 'getJSON', url: uri.toString(), headers: requestHeaders },
-					function (data){
-						$scope.$apply(function(){
-							$scope.addRequest(requestId.value, data);
-						});
-					}
+					function (data) { $scope.$apply(function(){ $scope.addRequest(requestId.value, data); }); }
 				);
 			}
 		});
+
+		chrome.devtools.inspectedWindow.eval('window.location', (location) => {
+			uri = new URI(location.href)
+
+			chrome.runtime.sendMessage(
+				{ action: 'getJSON', url: uri.path('/__clockwork/latest').setQuery('').toString() },
+				(data) => $scope.$apply(() => $scope.addRequest(data.id, data))
+			)
+		})
 	};
 
 	$scope.initStandalone = function()

--- a/Clockwork Chrome/manifest.json
+++ b/Clockwork Chrome/manifest.json
@@ -11,6 +11,7 @@
 	},
 	"permissions": [
 		"debugger",
+		"webRequest",
 		"http://*/",
 		"https://*/"
 	],


### PR DESCRIPTION
Clockwork now shows the last executed http request including any ajax requests when opened.

This is useful when testing an app and running into a slow load or a crash without having dev tools open, now we can simply open Clockwork and inspect the current request.