### PR TITLE
Added new "events" tab for apps using event dispatching

### DIFF
--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -114,6 +114,7 @@
 						<a tab-name="request" class="details-header-tab active" href="#">Request</a>
 						<a tab-name="timeline" ng-show="request.timeline.length" class="details-header-tab" href="#">Timeline</a>
 						<a tab-name="log" ng-show="request.log.length" class="details-header-tab" href="#">Log</a>
+						<a tab-name="events" ng-show="request.events.length" class="details-header-tab" href="#">Events</a>
 						<a tab-name="db" ng-show="request.databaseQueries.length" class="details-header-tab" href="#">Database</a>
 						<a tab-name="cache" ng-show="showCacheTab()" class="details-header-tab" href="#">Cache</a>
 						<a tab-name="session" ng-show="request.sessionData.length" class="details-header-tab" href="#">Session</a>
@@ -184,6 +185,58 @@
 								<tr ng-repeat="param in request.cookies">
 									<td class="key">{{param.name}}</td>
 									<td class="value"><pretty-print data="param.value"></pretty-print></td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+
+					<div tab-content="events">
+						<table stupid-table>
+							<thead>
+								<tr>
+									<th data-sort="string">Time</th>
+									<th data-sort="string">Event</th>
+									<th></th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr ng-repeat="event in request.events">
+									<td>{{event.time | date:'HH:mm:ss'}}</td>
+									<td>
+										<div class="fired-event">
+											<div class="fired-event-content">
+												<div ng-if="event.objectEvent">
+													<pretty-print data="event.data"></pretty-print>
+												</div>
+												<div ng-if="! event.objectEvent">
+													{{event.event}}
+												</div>
+											</div>
+											<div class="fired-event-path">
+												<div shortened-text="{{event.fullPath}}">{{event.shortPath}}</div>
+											</div>
+										</div>
+										<div class="fired-event-details" ng-show="isEventExpanded(event)">
+											<div class="fired-event-parameters" ng-if="! event.objectEvent">
+												<h4>Parameters</h4>
+												<pretty-print data="event.data"></pretty-print>
+											</div>
+											<div class="fired-event-listeners">
+												<h4>Listeners</h4>
+												<div ng-repeat="listener in event.listeners" shortened-text="{{listener.name}}">
+													{{listener.shortName}}
+												</div>
+											</div>
+										</div>
+									</td>
+									<td class="fired-event-actions">
+										<a href="#" ng-show="! isEventExpanded(event)" ng-click="toggleEvent(event)">
+											<span class="fa fa-chevron-down"></span>
+										</a>
+										<a href="#" ng-show="isEventExpanded(event)" ng-click="toggleEvent(event)">
+											<span class="fa fa-chevron-up"></span>
+										</a>
+									</td>
 								</tr>
 							</tbody>
 						</table>

--- a/Clockwork Chrome/assets/javascripts/directives/shortened-text.js
+++ b/Clockwork Chrome/assets/javascripts/directives/shortened-text.js
@@ -1,7 +1,7 @@
 Clockwork.directive('shortenedText', function () {
 	return {
 		link: function (scope, element, attrs) {
-			$(element).on('click', () => {
+			$(element).on('click', function () {
 				$(this).html($(this).attr('shortened-text'))
 			})
 		}

--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -9,6 +9,8 @@ Clockwork.controller('PanelController', function ($scope, $http, requests)
 	$scope.requestsListCollapsed = false
 	$scope.showIncomingRequests = true
 
+	$scope.expandedEvents = []
+
 	$scope.init = function () {
 		key('⌘+k, ctrl+l', () => $scope.$apply(() => $scope.clear()))
 
@@ -85,6 +87,8 @@ Clockwork.controller('PanelController', function ($scope, $http, requests)
 		$scope.timelineLegend = []
 
 		$scope.showIncomingRequests = true
+
+		$scope.expandedEvents = []
 	}
 
 	$scope.showRequest = function (id) {
@@ -159,6 +163,18 @@ Clockwork.controller('PanelController', function ($scope, $http, requests)
 
 	$scope.toggleRequestsList = function () {
 		$scope.requestsListCollapsed = ! $scope.requestsListCollapsed
+	}
+
+	$scope.isEventExpanded = function (event) {
+		return $scope.expandedEvents.indexOf(event) !== -1
+	}
+
+	$scope.toggleEvent = function (event) {
+		if ($scope.isEventExpanded(event)) {
+			$scope.expandedEvents = $scope.expandedEvents.filter(item => item != event)
+		} else {
+			$scope.expandedEvents.push(event)
+		}
 	}
 
 	angular.element(window).bind('resize', () => {

--- a/Clockwork Chrome/assets/javascripts/request.js
+++ b/Clockwork Chrome/assets/javascripts/request.js
@@ -13,6 +13,7 @@ class Request
 		this.cookies = this.createKeypairs(this.cookies)
 		this.databaseQueries = this.processDatabaseQueries(this.databaseQueries)
 		this.emails = this.processEmails(this.emailsData)
+		this.events = this.processEvents(this.events)
 		this.getData = this.createKeypairs(this.getData)
 		this.headers = this.processHeaders(this.headers)
 		this.log = this.processLog(this.log)
@@ -72,6 +73,32 @@ class Request
 		if (! (data instanceof Object)) return []
 
 		return Object.values(data).filter(email => email.data instanceof Object).map(email => email.data)
+	}
+
+	processEvents (data) {
+		if (! (data instanceof Array)) return []
+
+		return data.map(event => {
+			event.objectEvent = (event.event == event.data.__class__)
+			event.time = new Date(event.time * 1000)
+			event.fullPath = event.file && event.line ? event.file.replace(/^\//, '') + ':' + event.line : undefined
+			event.shortPath = event.fullPath ? event.fullPath.split(/[\/\\]/).pop() : undefined
+
+			event.listeners = event.listeners instanceof Array ? event.listeners : []
+			event.listeners = event.listeners.map(listener => {
+				let shortName, matches
+
+				if (matches = listener.match(/Closure \(.*[\/\\](.+?:\d+)-\d+\)/)) {
+					shortName = 'Closure (' + matches[1] + ')'
+				} else {
+					shortName = listener.split(/[\/\\]/).pop()
+				}
+
+				return { name: listener, shortName }
+			})
+
+			return event
+		})
 	}
 
 	processHeaders (data) {

--- a/Clockwork Chrome/assets/stylesheets/panel.css
+++ b/Clockwork Chrome/assets/stylesheets/panel.css
@@ -23,6 +23,16 @@ table {
   table th, table td {
     text-align: left; }
 
+a {
+  color: dimgray;
+  cursor: default; }
+  a:hover {
+    color: #3b3b3b; }
+    body.dark a:hover {
+      color: #fd9427; }
+  body.dark a {
+    color: gray; }
+
 .split-view {
   display: flex;
   flex-direction: column;
@@ -200,15 +210,7 @@ table {
     font-size: 15px;
     padding: 0 5px; }
     .details-header .icons a {
-      color: dimgray;
-      cursor: default;
       padding: 0 5px; }
-      .details-header .icons a:hover {
-        color: #3b3b3b; }
-        body.dark .details-header .icons a:hover {
-          color: #fd9427; }
-      body.dark .details-header .icons a {
-        color: gray; }
 
 .details-content {
   flex: 1;
@@ -327,6 +329,24 @@ table {
       margin-top: 3px; }
       body.dark .details-content .log-message .log-message-path {
         color: #777; }
+  .details-content .fired-event {
+    display: flex;
+    flex-wrap: wrap; }
+    .details-content .fired-event .fired-event-content {
+      flex: 1 0 auto;
+      max-width: 100%; }
+    .details-content .fired-event .fired-event-path {
+      color: #aaa;
+      flex: 0;
+      font-size: 90%;
+      margin-top: 3px; }
+      body.dark .details-content .fired-event .fired-event-path {
+        color: #777; }
+  .details-content .fired-event-details h4 {
+    margin: 6px 0 3px; }
+  .details-content .fired-event-actions {
+    padding-left: 5px;
+    width: 10px; }
   .details-content .database-query {
     display: flex;
     flex-wrap: wrap; }

--- a/Clockwork Chrome/assets/stylesheets/panel.scss
+++ b/Clockwork Chrome/assets/stylesheets/panel.scss
@@ -32,6 +32,23 @@ table {
 	}
 }
 
+a {
+	color: rgb(105, 105, 105);
+	cursor: default;
+
+	&:hover {
+		color: rgb(59, 59, 59);
+
+		body.dark & {
+			color: rgb(253, 148, 39);
+		}
+	}
+
+	body.dark & {
+		color: rgb(128, 128, 128);
+	}
+}
+
 // Split view
 
 .split-view {
@@ -323,21 +340,7 @@ table {
 		padding: 0 5px;
 
 		a {
-			color: rgb(105, 105, 105);
-			cursor: default;
 			padding: 0 5px;
-
-			&:hover {
-				color: rgb(59, 59, 59);
-
-				body.dark & {
-					color: rgb(253, 148, 39);
-				}
-			}
-
-			body.dark & {
-				color: rgb(128, 128, 128);
-			}
 		}
 	}
 }
@@ -538,6 +541,40 @@ table {
 				color: #777;
 			}
 		}
+	}
+
+	// Events tab
+
+	.fired-event {
+		display: flex;
+		flex-wrap: wrap;
+
+		.fired-event-content {
+			flex: 1 0 auto;
+			max-width: 100%;
+		}
+
+		.fired-event-path {
+			color: #aaa;
+			flex: 0;
+			font-size: 90%;
+			margin-top: 3px;
+
+			body.dark & {
+				color: #777;
+			}
+		}
+	}
+
+	.fired-event-details {
+		h4 {
+			margin: 6px 0 3px;
+		}
+	}
+
+	.fired-event-actions {
+		padding-left: 5px;
+		width: 10px;
 	}
 
 	// Database tab

--- a/Clockwork Chrome/vendor/assets/javascripts/pretty-jason.js
+++ b/Clockwork Chrome/vendor/assets/javascripts/pretty-jason.js
@@ -30,7 +30,8 @@ g.PrettyJason.prototype.generateHtml = function()
 
 	var $item = $('<li></li>');
 
-	var $itemName = $('<span><span class="pretty-jason-icon"><i class="pretty-jason-icon-closed"></i></span>Object </span>');
+	var className = this.data.__class__ || 'Object'
+	var $itemName = $('<span><span class="pretty-jason-icon"><i class="pretty-jason-icon-closed"></i></span>' + className + ' </span>');
 	var that = this;
 	$itemName.click(function(){ that._objectNodeClickedCallback(this); });
 	$itemName.data('rendered', true);
@@ -49,6 +50,8 @@ g.PrettyJason.prototype._generateHtmlNode = function(data)
 	var $list = $('<ul style="display:none"></ul>');
 
 	for (var key in data) {
+		if (key == '__class__') continue;
+
 		var val = data[key];
 		var valType = this._getValueType(val);
 		var $item;
@@ -60,7 +63,8 @@ g.PrettyJason.prototype._generateHtmlNode = function(data)
 		if (valType == 'object') {
 			$item = $('<li></li>');
 
-			var $itemName = $('<span><span class="pretty-jason-icon"><i class="pretty-jason-icon-closed"></i></span><span class="pretty-jason-key"></span> Object</span>');
+			var className = val.__class__ || 'Object'
+			var $itemName = $('<span><span class="pretty-jason-icon"><i class="pretty-jason-icon-closed"></i></span><span class="pretty-jason-key"></span> ' + className + '</span>');
 			$itemName.find('.pretty-jason-key').text(key + ':');
 			var that = this;
 			$itemName.click(function(){ that._objectNodeClickedCallback(this); });
@@ -84,6 +88,8 @@ g.PrettyJason.prototype._generateHtmlPreview = function(data)
 
 	var i = 0;
 	for (var key in data) {
+		if (key == '__class__') continue;
+
 		var val = data[key];
 		var valType = this._getValueType(val);
 		var $item;
@@ -93,7 +99,8 @@ g.PrettyJason.prototype._generateHtmlPreview = function(data)
 		}
 
 		if (valType == 'object') {
-			$item = $('<span class="pretty-jason-preview-item"><span class="pretty-jason-key"></span> <span class="pretty-jason-value">Object</span></span>');
+			var className = val.__class__ || 'Object'
+			$item = $('<span class="pretty-jason-preview-item"><span class="pretty-jason-key"></span> <span class="pretty-jason-value">' + className + '</span></span>');
 			$item.find('.pretty-jason-key').text(key + ':');
 			$item.find('.pretty-jason-value-' + valType).text(val);
 		} else {


### PR DESCRIPTION
- includes fired events, with names, pretty-printed payload, listeners and where the event was fired
- adds support for `__class__` metadata in pretty-jason, which can be used to override the default "Object" label for objects
- fixed shortened text not expanding on click
- server-side PR https://github.com/itsgoingd/clockwork/pull/182

![screenshot](http://abyss.shadowfall.eu/github/random/Screen%20Shot%202017-07-17%20at%2018.48.00.png)