### PR TITLE
Add "preserve log" feature

### DIFF
--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -127,6 +127,12 @@
 					</div>
 
 					<div class="icons">
+						<a href="#" title="Preserve log" ng-show="! preserveLog" ng-click="togglePreserveLog()">
+							<span class="fa fa-circle-o"></span>
+						</a>
+						<a href="#" title="Preserve log" ng-show="preserveLog" ng-click="togglePreserveLog()">
+							<span class="fa fa-circle"></span>
+						</a>
 						<a href="#" title="Clear" ng-click="clear()">
 							<span class="fa fa-ban"></span>
 						</a>

--- a/Clockwork Chrome/assets/javascripts/extension.js
+++ b/Clockwork Chrome/assets/javascripts/extension.js
@@ -42,6 +42,12 @@ class Extension
 	}
 
 	listenToRequests () {
+		this.api.devtools.network.onNavigated.addListener(url => {
+			if (! this.$scope.preserveLog) {
+				this.requests.clear()
+			}
+		})
+
 		if (! this.api.devtools.network.onRequestFinished) {
 			return this.listenToRequestsFirefox()
 		}

--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -6,6 +6,7 @@ Clockwork.controller('PanelController', function ($scope, $http, requests, updat
 	$scope.timelineLegend = []
 
 	$scope.loadingMoreRequests = false
+	$scope.preserveLog = true
 	$scope.requestsListCollapsed = false
 	$scope.showIncomingRequests = true
 
@@ -39,7 +40,9 @@ Clockwork.controller('PanelController', function ($scope, $http, requests, updat
 	$scope.refreshRequests = function (activeRequest) {
 		$scope.requests = requests.all()
 
-		if ($scope.showIncomingRequests && $scope.requests.length) {
+		if (! $scope.preserveLog) {
+			$scope.showRequest($scope.requests[0].id)
+		} else if ($scope.showIncomingRequests && $scope.requests.length) {
 			$scope.showRequest(activeRequest ? activeRequest.id : $scope.requests[$scope.requests.length - 1].id)
 			$scope.showIncomingRequests = true
 		}
@@ -137,6 +140,10 @@ Clockwork.controller('PanelController', function ($scope, $http, requests, updat
 		$scope.requestsListCollapsed = ! $scope.requestsListCollapsed
 	}
 
+	$scope.togglePreserveLog = function () {
+		$scope.preserveLog = ! $scope.preserveLog
+	}
+
 	$scope.isEventExpanded = function (event) {
 		return $scope.expandedEvents.indexOf(event) !== -1
 	}
@@ -154,7 +161,7 @@ Clockwork.controller('PanelController', function ($scope, $http, requests, updat
 
 		updateNotification.ignoreUpdate(requests.remoteUrl)
 	}
-	
+
 	angular.element(window).bind('resize', () => {
 		$scope.$apply(() => $scope.timelineLegend = $scope.generateTimelineLegend())
     })

--- a/Clockwork Chrome/assets/javascripts/requests.js
+++ b/Clockwork Chrome/assets/javascripts/requests.js
@@ -80,6 +80,10 @@ class Requests
 		this.client = client
 	}
 
+	setItems (items) {
+		this.items = items
+	}
+
 	setRemote (url, options) {
 		options = options || {}
 		options.path = options.path || '/__clockwork/'

--- a/Clockwork Chrome/assets/javascripts/standalone.js
+++ b/Clockwork Chrome/assets/javascripts/standalone.js
@@ -37,6 +37,10 @@ class Standalone
 		this.requests.loadNext(null, this.lastRequestId).then(() => {
 			if (this.requests.last()) this.lastRequestId = this.requests.last().id
 
+			if (! this.$scope.preserveLog) {
+				this.requests.setItems(this.requests.all().slice(-1))
+			}
+
 			this.$scope.refreshRequests()
 
 			setTimeout(() => this.pollRequests(), 1000)


### PR DESCRIPTION
- added "preserve log" feature, similar to dev tools network tab
- when enabled (default), new requests are appended to the requests list (same as before)
- when disabled, requests list is cleared when navigating to a new url (refresh, clicking link, etc)
- controlled by a new icon in the request details header next to clear icon