### PR TITLE
Rework request placeholders

### DIFF
--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -5,6 +5,7 @@
 		<link rel="stylesheet" type="text/css" href="assets/vendor/stylesheets/jquery.resizableColumns.css">
 		<link rel="stylesheet" type="text/css" href="assets/vendor/stylesheets/font-awesome.min.css">
 		<link rel="stylesheet" type="text/css" href="assets/vendor/stylesheets/pretty-jason.css">
+		<link rel="stylesheet" type="text/css" href="assets/vendor/stylesheets/spinkit.css">
 		<link rel="stylesheet" type="text/css" href="assets/stylesheets/panel.css">
 
 		<script src="assets/vendor/javascripts/jquery-3.2.1.slim.min.js"></script>
@@ -491,6 +492,23 @@
 						</table>
 					</div>
 
+				</div>
+
+				<div class="details-loading-overlay" ng-show="request.loading">
+					<div class="sk-fading-circle">
+						<div class="sk-circle1 sk-circle"></div>
+						<div class="sk-circle2 sk-circle"></div>
+						<div class="sk-circle3 sk-circle"></div>
+						<div class="sk-circle4 sk-circle"></div>
+						<div class="sk-circle5 sk-circle"></div>
+						<div class="sk-circle6 sk-circle"></div>
+						<div class="sk-circle7 sk-circle"></div>
+						<div class="sk-circle8 sk-circle"></div>
+						<div class="sk-circle9 sk-circle"></div>
+						<div class="sk-circle10 sk-circle"></div>
+						<div class="sk-circle11 sk-circle"></div>
+						<div class="sk-circle12 sk-circle"></div>
+					</div>
 				</div>
 
 			</div>

--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -511,6 +511,12 @@
 					</div>
 				</div>
 
+				<div class="details-error-overlay" ng-show="request.error">
+					<span class="fa fa-exclamation-circle"></span>
+					<p class="title">Error loading request metadata.</p>
+					<p class="message">{{ request.error }}</p>
+				</div>
+
 			</div>
 		</div>
 	</body>

--- a/Clockwork Chrome/assets/javascripts/chrome/background.js
+++ b/Clockwork Chrome/assets/javascripts/chrome/background.js
@@ -45,7 +45,7 @@ let lastClockworkRequestPerTab = {}
 api.webRequest.onCompleted.addListener(
 	request => {
 		if (request.responseHeaders.find((x) => x.name.toLowerCase() == 'x-clockwork-id')) {
-			lastClockworkRequestPerTab[request.tabId] = { url: request.url, headers: request.responseHeaders }
+			lastClockworkRequestPerTab[request.tabId] = request
 		}
 	},
 	{ urls: [ '<all_urls>' ], types: [ 'main_frame' ] },

--- a/Clockwork Chrome/assets/javascripts/extension.js
+++ b/Clockwork Chrome/assets/javascripts/extension.js
@@ -63,28 +63,30 @@ class Extension
 			this.updateNotification.serverVersion = options.version
 
 			this.requests.setRemote(message.request.url, options)
-			this.requests.loadId(options.id).then(activeRequest => {
-				this.$scope.$apply(() => this.$scope.refreshRequests(activeRequest))
+			this.requests.loadId(options.id, Request.placeholder(message.request)).then(() => {
+				this.$scope.$apply(() => this.$scope.refreshRequests())
 			})
+
+			this.$scope.$apply(() => this.$scope.refreshRequests())
 		})
 	}
 
 	loadLastRequest () {
 		this.api.runtime.sendMessage(
 			{ action: 'getLastClockworkRequestInTab', tabId: this.api.devtools.inspectedWindow.tabId },
-			(data) => {
-				if (! data) return
+			(request) => {
+				if (! request) return
 
-				let options = this.parseHeaders(data.headers)
+				let options = this.parseHeaders(request.responseHeaders)
 
 				this.updateNotification.serverVersion = options.version
 
-				this.requests.setRemote(data.url, options)
-				this.requests.loadId(options.id).then(() => {
-					this.requests.loadNext().then(activeRequest => {
-						this.$scope.$apply(() => this.$scope.refreshRequests(activeRequest))
-					})
+				this.requests.setRemote(request.url, options)
+				this.requests.loadId(options.id, Request.placeholder(request)).then(() => {
+					this.$scope.$apply(() => this.$scope.refreshRequests())
 				})
+
+				this.$scope.$apply(() => this.$scope.refreshRequests())
 			}
 		)
 	}

--- a/Clockwork Chrome/assets/javascripts/extension.js
+++ b/Clockwork Chrome/assets/javascripts/extension.js
@@ -34,10 +34,14 @@ class Extension
 	}
 
 	setMetadataClient () {
-		this.requests.setClient((url, headers, callback) => {
-			this.api.runtime.sendMessage(
-				{ action: 'getJSON', url, headers }, (data) => callback(data)
-			)
+		this.requests.setClient((url, headers) => {
+			return new Promise((accept, reject) => {
+				this.api.runtime.sendMessage(
+					{ action: 'getJSON', url, headers }, (message) => {
+						message.error ? reject(message.error) : accept(message.data)
+					}
+				)
+			})
 		})
 	}
 
@@ -63,7 +67,7 @@ class Extension
 			this.updateNotification.serverVersion = options.version
 
 			this.requests.setRemote(message.request.url, options)
-			this.requests.loadId(options.id, Request.placeholder(message.request)).then(() => {
+			this.requests.loadId(options.id, Request.placeholder(options.id, message.request)).then(() => {
 				this.$scope.$apply(() => this.$scope.refreshRequests())
 			})
 
@@ -82,7 +86,7 @@ class Extension
 				this.updateNotification.serverVersion = options.version
 
 				this.requests.setRemote(request.url, options)
-				this.requests.loadId(options.id, Request.placeholder(request)).then(() => {
+				this.requests.loadId(options.id, Request.placeholder(options.id, request)).then(() => {
 					this.$scope.$apply(() => this.$scope.refreshRequests())
 				})
 

--- a/Clockwork Chrome/assets/javascripts/request.js
+++ b/Clockwork Chrome/assets/javascripts/request.js
@@ -25,13 +25,14 @@ class Request
 	}
 
 	static placeholder (id, request) {
-		return new Request({
+		return Object.assign(new Request({
 			loading: true,
 			id: id,
 			uri: (new URI(request.url)).pathname(),
 			controller: 'Waiting...',
 			method: request.method,
-			responseStatus: '?',
+			responseStatus: '?'
+		}), {
 			responseDurationRounded: '?',
 			databaseDurationRounded: '?'
 		})

--- a/Clockwork Chrome/assets/javascripts/request.js
+++ b/Clockwork Chrome/assets/javascripts/request.js
@@ -3,7 +3,7 @@ class Request
 	constructor (data) {
 		Object.assign(this, data)
 
-		if (this.loading) return
+		if (data.loading) return
 
 		this.responseDurationRounded = this.responseDuration ? Math.round(this.responseDuration) : 0
 		this.databaseDurationRounded = this.databaseDuration ? Math.round(this.databaseDuration) : 0
@@ -24,6 +24,22 @@ class Request
 
 		this.errorsCount = this.getErrorsCount()
 		this.warningsCount = this.getWarningsCount()
+	}
+
+	static placeholder (request) {
+		return new Request({
+			loading: true,
+			uri: (new URI(request.url)).pathname(),
+			controller: 'Waiting...',
+			method: request.method,
+			responseStatus: '?',
+			responseDurationRounded: '?',
+			databaseDurationRounded: '?'
+		})
+	}
+
+	resolve (request) {
+		Object.assign(this, request, { loading: false })
 	}
 
 	createKeypairs (data) {

--- a/Clockwork Chrome/assets/javascripts/request.js
+++ b/Clockwork Chrome/assets/javascripts/request.js
@@ -3,8 +3,6 @@ class Request
 	constructor (data) {
 		Object.assign(this, data)
 
-		if (data.loading) return
-
 		this.responseDurationRounded = this.responseDuration ? Math.round(this.responseDuration) : 0
 		this.databaseDurationRounded = this.databaseDuration ? Math.round(this.databaseDuration) : 0
 
@@ -26,9 +24,10 @@ class Request
 		this.warningsCount = this.getWarningsCount()
 	}
 
-	static placeholder (request) {
+	static placeholder (id, request) {
 		return new Request({
 			loading: true,
+			id: id,
 			uri: (new URI(request.url)).pathname(),
 			controller: 'Waiting...',
 			method: request.method,
@@ -40,6 +39,12 @@ class Request
 
 	resolve (request) {
 		Object.assign(this, request, { loading: false })
+		return this
+	}
+
+	resolveWithError (error) {
+		Object.assign(this, { loading: false, error })
+		return this
 	}
 
 	createKeypairs (data) {
@@ -153,6 +158,8 @@ class Request
 	}
 
 	processTimeline (data) {
+		if (! (data instanceof Object)) return []
+
 		return Object.values(data).map((entry, i) => {
 			entry.style = 'style' + (i % 4 + 1)
 			entry.left = (entry.start - this.time) * 1000 / this.responseDuration * 100

--- a/Clockwork Chrome/assets/javascripts/requests.js
+++ b/Clockwork Chrome/assets/javascripts/requests.js
@@ -6,9 +6,7 @@ class Requests
 
 	// returns all requests up to the first placeholder, or everything if there are no placeholders
 	all () {
-		let placeholder = this.items.find(item => item.loading)
-
-		return placeholder ? this.items.slice(0, this.items.indexOf(placeholder)) : this.items
+		return this.items
 	}
 
 	// return request by id
@@ -17,21 +15,18 @@ class Requests
 	}
 
 	// loads request by id, inserts a placeholder to the items array which is replaced once the metadata is retrieved
-	loadId (id) {
+	loadId (id, placeholder) {
 		let request = this.findId(id)
 
 		if (request) return Promise.resolve(request)
 
-		let placeholder = new Request({ id: id, loading: true })
+		placeholder = placeholder || Request.placeholder()
+
 		this.items.push(placeholder)
 
 		return this.callRemote(this.remoteUrl + id).then(data => {
 			if (data[0]) {
-				if (this.items.indexOf(placeholder) != -1) {
-					this.items[this.items.indexOf(placeholder)] = data[0]
-				} else {
-					this.items.push(data[0])
-				}
+				placeholder.resolve(data[0])
 			} else {
 				this.items.splice(this.items.indexOf(placeholder), 1)
 			}

--- a/Clockwork Chrome/assets/javascripts/requests.js
+++ b/Clockwork Chrome/assets/javascripts/requests.js
@@ -20,25 +20,21 @@ class Requests
 
 		if (request) return Promise.resolve(request)
 
-		placeholder = placeholder || Request.placeholder()
+		placeholder = placeholder || Request.placeholder(id)
 
 		this.items.push(placeholder)
 
 		return this.callRemote(this.remoteUrl + id).then(data => {
-			if (data[0]) {
-				placeholder.resolve(data[0])
-			} else {
-				this.items.splice(this.items.indexOf(placeholder), 1)
-			}
-
-			return Promise.resolve(data[0])
+			return placeholder.resolve(data[0])
+		}).catch(error => {
+			placeholder.resolveWithError(error)
 		})
 	}
 
 	loadLatest () {
 		return this.callRemote(this.remoteUrl + 'latest').then(data => {
 			this.items.push(...data)
-		})
+		}).catch(error => {})
 	}
 
 	// loads requests after the last request, if the count isn't specified loads all requests
@@ -49,7 +45,7 @@ class Requests
 
 		return this.callRemote(this.remoteUrl + id + '/next' + (count ? '/' + count : '')).then(data => {
 			this.items.push(...data)
-		})
+		}).catch(error => {})
 	}
 
 	// loads requests before the first request, if the count isn't specified loads all requests
@@ -60,7 +56,7 @@ class Requests
 
 		return this.callRemote(this.remoteUrl + id + '/previous' + (count ? '/' + count : '')).then(data => {
 			this.items.unshift(...data)
-		})
+		}).catch(error => {})
 	}
 
 	clear () {
@@ -98,10 +94,8 @@ class Requests
 	}
 
 	callRemote (url) {
-		return new Promise((accept, reject) => {
-			this.client(url, this.remoteHeaders, data => {
-				accept((data instanceof Array ? data : [ data ]).map(data => new Request(data)))
-			})
+		return this.client(url, this.remoteHeaders).then(data => {
+			return ((data instanceof Array) ? data : [ data ]).map(data => new Request(data))
 		})
 	}
 }

--- a/Clockwork Chrome/assets/javascripts/standalone.js
+++ b/Clockwork Chrome/assets/javascripts/standalone.js
@@ -20,8 +20,8 @@ class Standalone
 	}
 
 	setMetadataClient () {
-		this.requests.setClient((url, headers, callback) => {
-			this.$http.get(url).then(data => callback(data.data))
+		this.requests.setClient((url, headers) => {
+			return this.$http.get(url).then(data => data.data)
 		})
 	}
 
@@ -30,6 +30,8 @@ class Standalone
 			this.lastRequestId = this.requests.last().id
 
 			this.pollRequests()
+		}).catch(() => {
+			setTimeout(() => this.startPollingRequests(), 1000)
 		})
 	}
 
@@ -43,6 +45,8 @@ class Standalone
 
 			this.$scope.refreshRequests()
 
+			setTimeout(() => this.pollRequests(), 1000)
+		}).catch(() => {
 			setTimeout(() => this.pollRequests(), 1000)
 		})
 	}

--- a/Clockwork Chrome/assets/stylesheets/panel.css
+++ b/Clockwork Chrome/assets/stylesheets/panel.css
@@ -183,7 +183,8 @@ a {
 
 .split-view-details {
   display: flex;
-  flex-direction: column; }
+  flex-direction: column;
+  position: relative; }
 
 .details-header {
   border-bottom: 1px solid #cccccc;
@@ -371,6 +372,18 @@ a {
   .details-content .cache-query-type {
     font-size: 125%;
     font-variant: small-caps; }
+
+.details-loading-overlay {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-size: 16px;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%; }
 
 .number-of-queries {
   font-size: 11px;

--- a/Clockwork Chrome/assets/stylesheets/panel.css
+++ b/Clockwork Chrome/assets/stylesheets/panel.css
@@ -373,7 +373,7 @@ a {
     font-size: 125%;
     font-variant: small-caps; }
 
-.details-loading-overlay {
+.details-loading-overlay, .details-error-overlay {
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -384,6 +384,14 @@ a {
   position: absolute;
   top: 0;
   width: 100%; }
+  .details-loading-overlay .fa, .details-error-overlay .fa {
+    font-size: 46px; }
+  .details-loading-overlay .title, .details-error-overlay .title {
+    margin: 10px 0 0 0; }
+  .details-loading-overlay .message, .details-error-overlay .message {
+    color: #aaa;
+    font-size: 75%;
+    margin: 5px 0 0 0; }
 
 .number-of-queries {
   font-size: 11px;

--- a/Clockwork Chrome/assets/stylesheets/panel.scss
+++ b/Clockwork Chrome/assets/stylesheets/panel.scss
@@ -622,7 +622,7 @@ a {
 	}
 }
 
-.details-loading-overlay {
+.details-loading-overlay, .details-error-overlay {
 	align-items: center;
 	display: flex;
 	flex-direction: column;
@@ -633,6 +633,20 @@ a {
 	position: absolute;
 	top: 0;
 	width: 100%;
+
+	.fa {
+		font-size: 46px;
+	}
+
+	.title {
+		margin: 10px 0 0 0;
+	}
+
+	.message {
+		color: #aaa;
+		font-size: 75%;
+		margin: 5px 0 0 0;
+	}
 }
 
 .number-of-queries {

--- a/Clockwork Chrome/assets/stylesheets/panel.scss
+++ b/Clockwork Chrome/assets/stylesheets/panel.scss
@@ -302,6 +302,7 @@ a {
 .split-view-details {
 	display: flex;
 	flex-direction: column;
+	position: relative;
 }
 
 .details-header {
@@ -619,6 +620,19 @@ a {
 		font-size: 125%;
 		font-variant: small-caps;
 	}
+}
+
+.details-loading-overlay {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	font-size: 16px;
+	height: 100%;
+	justify-content: center;
+	left: 0;
+	position: absolute;
+	top: 0;
+	width: 100%;
 }
 
 .number-of-queries {

--- a/Clockwork Chrome/assets/vendor/stylesheets/spinkit.css
+++ b/Clockwork Chrome/assets/vendor/stylesheets/spinkit.css
@@ -1,0 +1,134 @@
+.sk-fading-circle {
+  width: 40px;
+  height: 40px;
+  position: relative;
+}
+
+.sk-fading-circle .sk-circle {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.sk-fading-circle .sk-circle:before {
+  content: '';
+  display: block;
+  margin: 0 auto;
+  width: 15%;
+  height: 15%;
+  background-color: #333;
+  border-radius: 100%;
+  -webkit-animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
+          animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
+}
+.sk-fading-circle .sk-circle2 {
+  -webkit-transform: rotate(30deg);
+      -ms-transform: rotate(30deg);
+          transform: rotate(30deg);
+}
+.sk-fading-circle .sk-circle3 {
+  -webkit-transform: rotate(60deg);
+      -ms-transform: rotate(60deg);
+          transform: rotate(60deg);
+}
+.sk-fading-circle .sk-circle4 {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg);
+}
+.sk-fading-circle .sk-circle5 {
+  -webkit-transform: rotate(120deg);
+      -ms-transform: rotate(120deg);
+          transform: rotate(120deg);
+}
+.sk-fading-circle .sk-circle6 {
+  -webkit-transform: rotate(150deg);
+      -ms-transform: rotate(150deg);
+          transform: rotate(150deg);
+}
+.sk-fading-circle .sk-circle7 {
+  -webkit-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg);
+}
+.sk-fading-circle .sk-circle8 {
+  -webkit-transform: rotate(210deg);
+      -ms-transform: rotate(210deg);
+          transform: rotate(210deg);
+}
+.sk-fading-circle .sk-circle9 {
+  -webkit-transform: rotate(240deg);
+      -ms-transform: rotate(240deg);
+          transform: rotate(240deg);
+}
+.sk-fading-circle .sk-circle10 {
+  -webkit-transform: rotate(270deg);
+      -ms-transform: rotate(270deg);
+          transform: rotate(270deg);
+}
+.sk-fading-circle .sk-circle11 {
+  -webkit-transform: rotate(300deg);
+      -ms-transform: rotate(300deg);
+          transform: rotate(300deg);
+}
+.sk-fading-circle .sk-circle12 {
+  -webkit-transform: rotate(330deg);
+      -ms-transform: rotate(330deg);
+          transform: rotate(330deg);
+}
+.sk-fading-circle .sk-circle2:before {
+  -webkit-animation-delay: -1.1s;
+          animation-delay: -1.1s;
+}
+.sk-fading-circle .sk-circle3:before {
+  -webkit-animation-delay: -1s;
+          animation-delay: -1s;
+}
+.sk-fading-circle .sk-circle4:before {
+  -webkit-animation-delay: -0.9s;
+          animation-delay: -0.9s;
+}
+.sk-fading-circle .sk-circle5:before {
+  -webkit-animation-delay: -0.8s;
+          animation-delay: -0.8s;
+}
+.sk-fading-circle .sk-circle6:before {
+  -webkit-animation-delay: -0.7s;
+          animation-delay: -0.7s;
+}
+.sk-fading-circle .sk-circle7:before {
+  -webkit-animation-delay: -0.6s;
+          animation-delay: -0.6s;
+}
+.sk-fading-circle .sk-circle8:before {
+  -webkit-animation-delay: -0.5s;
+          animation-delay: -0.5s;
+}
+.sk-fading-circle .sk-circle9:before {
+  -webkit-animation-delay: -0.4s;
+          animation-delay: -0.4s;
+}
+.sk-fading-circle .sk-circle10:before {
+  -webkit-animation-delay: -0.3s;
+          animation-delay: -0.3s;
+}
+.sk-fading-circle .sk-circle11:before {
+  -webkit-animation-delay: -0.2s;
+          animation-delay: -0.2s;
+}
+.sk-fading-circle .sk-circle12:before {
+  -webkit-animation-delay: -0.1s;
+          animation-delay: -0.1s;
+}
+
+@-webkit-keyframes sk-circleFadeDelay {
+  0%, 39%, 100% { opacity: 0; }
+  40% { opacity: 1; }
+}
+
+@keyframes sk-circleFadeDelay {
+  0%, 39%, 100% { opacity: 0; }
+  40% { opacity: 1; }
+}


### PR DESCRIPTION
- reworked the use of placeholders, placeholders are now shown in the requests list, pre-filled with data available from the http request and resolved with full metadata once available
- reworked metadata loading error handling, requests where metadata loading failed now show an error message instead just being blank
- this should resolve the issue of random empty requests being shown in the requests list and improve the responsiveness of the requests list overall