### PR TITLE
Dark mode support when running as standalone app

### DIFF
--- a/Clockwork Chrome/assets/javascripts/standalone.js
+++ b/Clockwork Chrome/assets/javascripts/standalone.js
@@ -7,10 +7,28 @@ class Standalone
 	}
 
 	init () {
+		this.useProperTheme()
 		this.setMetadataUrl()
 		this.setMetadataClient()
 
 		this.startPollingRequests()
+	}
+
+	// dark theme can be activated by adding ?dark or ?dark=1 query string to the url, the setting is preserved
+	// and can be deactivated again by adding ?dark=0
+	useProperTheme () {
+		let wantsDarkTheme = URI(window.location.href).query(true).dark
+
+		if (wantsDarkTheme === undefined) {
+			wantsDarkTheme = localStorage.getItem('use-dark-theme') == 'true'
+		} else {
+			wantsDarkTheme = wantsDarkTheme == '1' || wantsDarkTheme === null
+			localStorage.setItem('use-dark-theme', wantsDarkTheme)
+		}
+
+		if (wantsDarkTheme) {
+			$('body').addClass('dark')
+		}
 	}
 
 	setMetadataUrl () {


### PR DESCRIPTION
- added support for activating dark mode when running as a standalone web app (https://underground.works/clockwork/__clockwork/app)
- appending `?dark` or `?dark=1` to url activates the dark theme
- the setting is persistent
- appending `?dark=0` disables the dark theme

<img width="1392" alt="screen shot 2018-03-23 at 13 03 11" src="https://user-images.githubusercontent.com/821582/37828376-42d91cd2-2e9b-11e8-949f-f2da8d8e90c6.png">