### PR TITLE
Database tab stats

### DIFF
--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -349,6 +349,38 @@
 					</div>
 
 					<div tab-content="db">
+
+						<div class="counters-row">
+							<div class="counter">
+								<div class="counter-value">{{databaseQueriesStats.queries}}</div>
+								<div class="counter-title">queries</div>
+							</div>
+							<div class="counter" ng-show="databaseQueriesStats.selects">
+								<div class="counter-value">{{databaseQueriesStats.selects}}</div>
+								<div class="counter-title">selects</div>
+							</div>
+							<div class="counter" ng-show="databaseQueriesStats.inserts">
+								<div class="counter-value">{{databaseQueriesStats.inserts}}</div>
+								<div class="counter-title">inserts</div>
+							</div>
+							<div class="counter" ng-show="databaseQueriesStats.updates">
+								<div class="counter-value">{{databaseQueriesStats.updates}}</div>
+								<div class="counter-title">updates</div>
+							</div>
+							<div class="counter" ng-show="databaseQueriesStats.deletes">
+								<div class="counter-value">{{databaseQueriesStats.deletes}}</div>
+								<div class="counter-title">deletes</div>
+							</div>
+							<div class="counter" ng-show="databaseQueriesStats.other">
+								<div class="counter-value">{{databaseQueriesStats.other}}</div>
+								<div class="counter-title">other</div>
+							</div>
+							<div class="counter">
+								<div class="counter-value">{{request.databaseDurationRounded}} ms</div>
+								<div class="counter-title">time</div>
+							</div>
+						</div>
+
 						<table>
 							<thead>
 								<tr>

--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -437,6 +437,10 @@
 
 					<div tab-content="cache">
 						<div class="counters-row">
+							<div class="counter" ng-show="request.cacheQueries.length">
+								<div class="counter-value">{{request.cacheQueries.length}}</div>
+								<div class="counter-title">queries</div>
+							</div>
 							<div class="counter" ng-show="request.cacheReads !== null">
 								<div class="counter-value">{{request.cacheReads}}</div>
 								<div class="counter-title">reads</div>

--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -376,7 +376,7 @@
 								<div class="counter-title">other</div>
 							</div>
 							<div class="counter">
-								<div class="counter-value">{{request.databaseDurationRounded}} ms</div>
+								<div class="counter-value">{{request.databaseDurationRounded}}&nbsp;ms</div>
 								<div class="counter-title">time</div>
 							</div>
 						</div>
@@ -432,7 +432,6 @@
 								</tr>
 							</tbody>
 						</table>
-						<div class="number-of-queries">Number of queries: {{request.databaseQueries.length}}</div>
 					</div>
 
 					<div tab-content="cache">
@@ -531,7 +530,6 @@
 								</tr>
 							</tbody>
 						</table>
-						<div class="number-of-queries">Number of queries: {{request.cacheQueries.length}}</div>
 					</div>
 
 					<div tab-content="log">
@@ -594,11 +592,11 @@
 								</div>
 							</div>
 							<div ng-repeat="metric in request.performanceMetrics" class="counter performance-chart-legend {{ metric.style }}">
-								<div class="counter-value">{{metric.value}} ms</div>
+								<div class="counter-value">{{metric.value}}&nbsp;ms</div>
 								<div class="counter-title">{{metric.name}}</div>
 							</div>
 							<div class="counter" ng-show="request.responseDurationRounded">
-								<div class="counter-value">{{request.responseDurationRounded}} ms</div>
+								<div class="counter-value">{{request.responseDurationRounded}}&nbsp;ms</div>
 								<div class="counter-title">total</div>
 							</div>
 						</div>
@@ -730,7 +728,6 @@
 								</tr>
 							</tbody>
 						</table>
-						<div class="number-of-queries">Number of emails: {{request.emails.length}}</div>
 					</div>
 
 					<div tab-content="routes">

--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -131,6 +131,7 @@ Clockwork.controller('PanelController', function ($scope, $http, filter, request
 		$scope.performanceMetricsChartValues = $scope.getPerformanceMetricsChartValues()
 		$scope.performanceMetricsChartColors = $scope.getPerformanceMetricsChartColors()
 		$scope.performanceMetricsChartOptions = $scope.getPerformanceMetricsChartOptions()
+		$scope.databaseQueriesStats = $scope.getDatabaseQueriesStats()
 		$scope.timelineLegend = $scope.generateTimelineLegend()
 
 		$scope.showIncomingRequests = (id == $scope.requests[$scope.requests.length - 1].id)
@@ -173,6 +174,17 @@ Clockwork.controller('PanelController', function ($scope, $http, filter, request
 			.filter((connection, i, connections) => connections.indexOf(connection) == i)
 
 		return connnections.length > 1
+	}
+
+	$scope.getDatabaseQueriesStats = function () {
+		return {
+			queries: $scope.request.databaseQueries.length,
+			selects: $scope.request.databaseQueries.filter(query => query.query.match(/^select /i)).length,
+			inserts: $scope.request.databaseQueries.filter(query => query.query.match(/^insert /i)).length,
+			updates: $scope.request.databaseQueries.filter(query => query.query.match(/^update /i)).length,
+			deletes: $scope.request.databaseQueries.filter(query => query.query.match(/^delete /i)).length,
+			other: $scope.request.databaseQueries.filter(query => ! query.query.match(/^(select|insert|update|delete) /i)).length
+		}
 	}
 
 	$scope.showCacheTab = function () {

--- a/Clockwork Chrome/assets/stylesheets/panel.css
+++ b/Clockwork Chrome/assets/stylesheets/panel.css
@@ -492,11 +492,6 @@ a {
     font-size: 75%;
     margin: 5px 0 0 0; }
 
-.number-of-queries {
-  font-size: 11px;
-  padding: 7px 0 0 5px;
-  font-weight: bold; }
-
 .update-notification, .parent-request {
   background: #e9f3fb;
   border-radius: 3px;

--- a/Clockwork Chrome/assets/stylesheets/panel.scss
+++ b/Clockwork Chrome/assets/stylesheets/panel.scss
@@ -832,12 +832,6 @@ a {
 	}
 }
 
-.number-of-queries {
-	font-size: 11px;
-	padding: 7px 0 0 5px;
-	font-weight: bold;
-}
-
 .update-notification, .parent-request {
 	background: hsl(206, 71%, 95%);
 	border-radius: 3px;


### PR DESCRIPTION
- added query counters on top of database tab
- added total query count for cache tab
- removed old query numbers form the bottom of tabs

<img width="1392" alt="screen shot 2018-03-24 at 22 51 28" src="https://user-images.githubusercontent.com/821582/37869332-0927ba18-2fb6-11e8-8e7a-7a1a9f8faee5.png">
