### PR TITLE
Better exceptions UI

### DIFF
--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -246,6 +246,20 @@
 							</div>
 						</div>
 
+						<div class="request-tab-exception" ng-if="request.exceptions.length">
+							<div class="exception-info" ng-repeat="exception in request.exceptions">
+								<div class="exception-message">
+									<h3>{{exception.type}} <small ng-if="exception.code">#{{exception.code}}</small></h3>
+
+									{{exception.message}}
+								</div>
+								<div>
+									<a href="#" class="exception-previous" ng-click="showPreviousRequestException($event, exception)" ng-if="exception.previous">Previous</a>
+									<stack-trace class="exception-trace" trace="exception.trace" short-path="'Trace'"></stack-trace>
+								</div>
+							</div>
+						</div>
+
 						<table ng-show="request.headers.length">
 							<thead>
 								<tr>
@@ -651,7 +665,7 @@
 												</div>
 											</div>
 											<div class="log-message-exception" ng-if="message.exception">
-												<a href="#" class="exception-previous" ng-if="message.exception.previous" ng-click="showPreviousException($event, message)">Show previous</a>
+												<a href="#" class="exception-previous" ng-if="message.exception.previous" ng-click="showPreviousLogException($event, message)">Show previous</a>
 												<span class="exception-type">{{message.exception.type}}</span>
 												<span class="exception-code" ng-if="message.exception.code">#{{message.exception.code}}</span>
 											</div>

--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -650,6 +650,11 @@
 													<pretty-print data="message.context"></pretty-print>
 												</div>
 											</div>
+											<div class="log-message-exception" ng-if="message.exception">
+												<a href="#" class="exception-previous" ng-if="message.exception.previous" ng-click="showPreviousException($event, message)">Show previous</a>
+												<span class="exception-type">{{message.exception.type}}</span>
+												<span class="exception-code" ng-if="message.exception.code">#{{message.exception.code}}</span>
+											</div>
 											<stack-trace class="log-message-path" trace="message.trace" short-path="message.shortPath" full-path="message.fullPath"></stack-trace>
 										</div>
 									</td>

--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -309,7 +309,15 @@ Clockwork.controller('PanelController', function ($scope, $q, $http, filter, pro
 		$scope.preserveLog = ! $scope.preserveLog
 	}
 
-	$scope.showPreviousException = function (event, message) {
+	$scope.showPreviousRequestException = function (event, exception) {
+		event.preventDefault()
+
+		$scope.request.exceptions.push(exception.previous)
+
+		exception.previous = undefined
+	}
+
+	$scope.showPreviousLogException = function (event, message) {
 		event.preventDefault()
 
 		let messageIndex = $scope.request.log.indexOf(message)

--- a/Clockwork Chrome/assets/javascripts/panel.js
+++ b/Clockwork Chrome/assets/javascripts/panel.js
@@ -309,6 +309,22 @@ Clockwork.controller('PanelController', function ($scope, $q, $http, filter, pro
 		$scope.preserveLog = ! $scope.preserveLog
 	}
 
+	$scope.showPreviousException = function (event, message) {
+		event.preventDefault()
+
+		let messageIndex = $scope.request.log.indexOf(message)
+
+		$scope.request.log.splice(messageIndex + 1, 0, {
+			message:   message.exception.previous.message,
+			exception: message.exception.previous,
+			level:     'error',
+			shortPath: `${message.exception.previous.file.split(/[\/\\]/).pop()}:${message.exception.previous.line}`,
+			trace:     message.exception.previous.trace
+		})
+
+		message.exception.previous = undefined
+	}
+
 	$scope.isEventExpanded = function (event) {
 		return $scope.expandedEvents.indexOf(event) !== -1
 	}

--- a/Clockwork Chrome/assets/javascripts/request.js
+++ b/Clockwork Chrome/assets/javascripts/request.js
@@ -25,6 +25,7 @@ class Request
 
 		this.errorsCount = this.getErrorsCount()
 		this.warningsCount = this.getWarningsCount()
+		this.exceptions = this.processExceptions()
 	}
 
 	static placeholder (id, request, parent) {
@@ -133,6 +134,27 @@ class Request
 
 			return event
 		})
+	}
+
+	processExceptions () {
+		let exception = this.log.length ? this.log[this.log.length - 1].exception : null
+
+		if (this.responseStatus != 500 || ! exception) return []
+
+		exception = angular.copy(exception)
+
+		let current = exception;
+
+		do {
+			current.trace = this.processStackTrace([ {
+				call:     `${current.type}()`,
+				file:     current.file,
+				line:     current.line,
+				isVendor: false
+			}, ...current.trace ])
+		} while (current = current.previous)
+
+		return [ exception ]
 	}
 
 	processHeaders (data) {

--- a/Clockwork Chrome/assets/javascripts/request.js
+++ b/Clockwork Chrome/assets/javascripts/request.js
@@ -161,6 +161,12 @@ class Request
 		if (! (data instanceof Array)) return []
 
 		return data.map(message => {
+			if (message.exception) {
+				message.file = message.exception.file
+				message.line = message.exception.line
+				message.trace = message.exception.trace
+			}
+
 			message.time = new Date(message.time * 1000)
 			message.context = message.context instanceof Object && Object.keys(message.context).filter(key => key != '__type__').length ? message.context : undefined
 			message.fullPath = message.file && message.line ? message.file.replace(/^\//, '') + ':' + message.line : undefined

--- a/Clockwork Chrome/assets/stylesheets/panel.css
+++ b/Clockwork Chrome/assets/stylesheets/panel.css
@@ -354,6 +354,44 @@ a {
       .details-content .request-tab-info .field.link {
         font-size: 90%;
         padding: 0; }
+  .details-content .request-tab-exception {
+    margin: 10px -10px; }
+    .details-content .request-tab-exception .exception-info {
+      align-items: center;
+      background: #ffebeb;
+      color: #c51f24;
+      display: flex;
+      padding: 10px 30px; }
+      .details-content .request-tab-exception .exception-info:nth-child(even) {
+        background: #ffe0e0; }
+      .details-content .request-tab-exception .exception-info:first-child {
+        padding-top: 15px; }
+      .details-content .request-tab-exception .exception-info:last-child {
+        padding-bottom: 15px; }
+      body.dark .details-content .request-tab-exception .exception-info {
+        background: #380000;
+        color: #ed797a; }
+        body.dark .details-content .request-tab-exception .exception-info:nth-child(even) {
+          background: #2e0000; }
+      .details-content .request-tab-exception .exception-info h3 {
+        border-bottom: 0;
+        padding: 6px 0; }
+      .details-content .request-tab-exception .exception-info .exception-message {
+        flex: 1;
+        font-size: 15px;
+        line-height: 1.5; }
+      .details-content .request-tab-exception .exception-info .exception-previous, .details-content .request-tab-exception .exception-info .exception-trace .stack-trace > a {
+        border: 1px solid #aaa;
+        border-radius: 4px;
+        font-size: 11px;
+        font-variant: small-caps;
+        padding: 3px 12px;
+        text-transform: uppercase; }
+      .details-content .request-tab-exception .exception-info .exception-previous {
+        margin-right: 4px;
+        text-decoration: none; }
+      .details-content .request-tab-exception .exception-info .exception-trace {
+        display: inline-block; }
   .details-content .performance-chart-container {
     flex: 0 1 100px; }
   .details-content .performance-chart {

--- a/Clockwork Chrome/assets/stylesheets/panel.css
+++ b/Clockwork Chrome/assets/stylesheets/panel.css
@@ -605,6 +605,17 @@ a {
     .details-content .log-message .log-message-content {
       flex: 1 0 auto;
       max-width: 100%; }
+    .details-content .log-message .log-message-exception {
+      flex: 0;
+      font-size: 90%;
+      margin: 3px 5px 0 0;
+      white-space: nowrap; }
+      .details-content .log-message .log-message-exception .exception-previous {
+        border: 1px solid #aaa;
+        border-radius: 4px;
+        text-decoration: none;
+        padding: 2px 4px;
+        margin-right: 5px; }
     .details-content .log-message .log-message-path {
       color: #aaa;
       flex: 0;

--- a/Clockwork Chrome/assets/stylesheets/panel.scss
+++ b/Clockwork Chrome/assets/stylesheets/panel.scss
@@ -583,6 +583,68 @@ a {
 		}
 	}
 
+	.request-tab-exception {
+	    margin: 10px -10px;
+
+		.exception-info {
+			align-items: center;
+			background: rgb(255, 235, 235);
+			color: rgb(197, 31, 36);
+		    display: flex;
+		    padding: 10px 30px;
+
+			&:nth-child(even) {
+				background: hsl(0, 100%, 94%);
+			}
+
+			&:first-child {
+				padding-top: 15px;
+			}
+
+			&:last-child {
+				padding-bottom: 15px;
+			}
+
+			body.dark & {
+				background: hsl(0, 100%, 11%);
+				color: rgb(237, 121, 122);
+
+				&:nth-child(even) {
+					background: hsl(0, 100%, 9%);
+				}
+			}
+
+			h3 {
+			    border-bottom: 0;
+		        padding: 6px 0;
+			}
+
+		    .exception-message {
+			    flex: 1;
+	    	    font-size: 15px;
+			    line-height: 1.5;
+		    }
+
+    		.exception-previous, .exception-trace .stack-trace > a {
+	    	    border: 1px solid #aaa;
+			    border-radius: 4px;
+			    font-size: 11px;
+			    font-variant: small-caps;
+				padding: 3px 12px;
+			    text-transform: uppercase;
+			}
+
+			.exception-previous {
+				margin-right: 4px;
+				text-decoration: none;
+			}
+
+			.exception-trace {
+				display: inline-block;
+			}
+		}
+	}
+
 	// Performance tab
 
 	.performance-chart-container {

--- a/Clockwork Chrome/assets/stylesheets/panel.scss
+++ b/Clockwork Chrome/assets/stylesheets/panel.scss
@@ -1041,6 +1041,21 @@ a {
 			max-width: 100%;
 		}
 
+		.log-message-exception {
+			flex: 0;
+			font-size: 90%;
+			margin: 3px 5px 0 0;
+		    white-space: nowrap;
+
+		    .exception-previous {
+	    	    border: 1px solid #aaa;
+			    border-radius: 4px;
+			    text-decoration: none;
+			    padding: 2px 4px;
+			    margin-right: 5px;
+		    }
+		}
+
 		.log-message-path {
 			color: #aaa;
 			flex: 0;


### PR DESCRIPTION
- improves how log messages including exceptions are displayed in log tab (includes exception class, code and proper stack trace)
- shows last exception right in the request tab for HTTP 500 requests (same improved format as log tab)
- both UIs support chained (previous) exceptions
- server-side PR - https://github.com/itsgoingd/clockwork/pull/297

<img width="1238" alt="screenshot 2018-11-05 at 16 07 30" src="https://user-images.githubusercontent.com/821582/48005941-f91fb380-e114-11e8-99b3-2e09c662d478.png">

<img width="1238" alt="screenshot 2018-11-05 at 16 07 43" src="https://user-images.githubusercontent.com/821582/48005949-fe7cfe00-e114-11e8-86a9-6afd7b0e0254.png">
