### PR TITLE
Local storage fallback

### DIFF
--- a/Clockwork Chrome/app.html
+++ b/Clockwork Chrome/app.html
@@ -31,6 +31,7 @@
 		<script src="assets/javascripts/authentication.js"></script>
 		<script src="assets/javascripts/extension.js"></script>
 		<script src="assets/javascripts/filter.js"></script>
+		<script src="assets/javascripts/local-store.js"></script>
 		<script src="assets/javascripts/panel.js"></script>
 		<script src="assets/javascripts/profiler.js"></script>
 		<script src="assets/javascripts/request.js"></script>

--- a/Clockwork Chrome/assets/javascripts/local-store.js
+++ b/Clockwork Chrome/assets/javascripts/local-store.js
@@ -1,0 +1,27 @@
+class LocalStore
+{
+	static isPersistent() {
+		try {
+			return localStorage !== undefined
+		} catch (e) {
+			return false
+		}
+	}
+
+	static get(key) {
+		try {
+			return JSON.parse(localStorage.getItem(key))
+		} catch (e) {
+			return this.temporary ? this.temporary[key] : undefined
+		}
+	}
+
+	static set(key, value) {
+		try {
+			localStorage.setItem(key, JSON.stringify(value))
+		} catch (e) {
+			if (! this.temporary) this.temporary = {}
+			this.temporary[key] = value
+		}
+	}
+}

--- a/Clockwork Chrome/assets/javascripts/requests.js
+++ b/Clockwork Chrome/assets/javascripts/requests.js
@@ -3,9 +3,7 @@ class Requests
 	constructor () {
 		this.items = []
 
-		try {
-			this.tokens = JSON.parse(localStorage.getItem('requests.tokens'))
-		} catch (e) {}
+		this.tokens = LocalStore.get('requests.tokens')
 
 		if (! (this.tokens instanceof Object)) this.tokens = {}
 	}
@@ -114,7 +112,7 @@ class Requests
 
 	setAuthenticationToken (token) {
 		this.tokens[this.remoteUrl] = token
-		localStorage.setItem('requests.tokens', JSON.stringify(this.tokens))
+		LocalStore.set('requests.tokens', this.tokens)
 	}
 
 	callRemote (url) {

--- a/Clockwork Chrome/assets/javascripts/settings.js
+++ b/Clockwork Chrome/assets/javascripts/settings.js
@@ -43,7 +43,7 @@ class Settings
 	save() {
 		let settings = angular.merge(this.loadSettings(), this.settings)
 
-		localStorage.setItem('settings', JSON.stringify(settings))
+		LocalStore.set('settings', settings)
 	}
 
 	reload() {
@@ -53,6 +53,6 @@ class Settings
 	loadSettings() {
 		let defaultSettings = { global: { editor: null }, site: {} }
 
-		return angular.merge(defaultSettings, JSON.parse(localStorage.getItem('settings')));
+		return angular.merge(defaultSettings, LocalStore.get('settings'));
 	}
 }

--- a/Clockwork Chrome/assets/javascripts/standalone.js
+++ b/Clockwork Chrome/assets/javascripts/standalone.js
@@ -21,10 +21,10 @@ class Standalone
 		let wantsDarkTheme = URI(window.location.href).query(true).dark
 
 		if (wantsDarkTheme == '1' || wantsDarkTheme == '0')	{
-			localStorage.setItem('use-dark-theme', wantsDarkTheme)
+			LocalStore.set('use-dark-theme', wantsDarkTheme)
 			wantsDarkTheme = wantsDarkTheme == '1'
-		} else if (localStorage.getItem('use-dark-theme')) {
-			wantsDarkTheme = localStorage.getItem('use-dark-theme') == '1'
+		} else if (LocalStore.get('use-dark-theme')) {
+			wantsDarkTheme = LocalStore.get('use-dark-theme') == '1'
 		} else {
 			wantsDarkTheme = wantsDarkTheme === null
 		}

--- a/Clockwork Chrome/assets/javascripts/update-notification.js
+++ b/Clockwork Chrome/assets/javascripts/update-notification.js
@@ -1,11 +1,7 @@
 class UpdateNotification
 {
 	get ignoredUpdates() {
-		try {
-			return JSON.parse(localStorage.getItem('update-notification.ignored-updates') || '{}')
-		} catch (e) {
-			return {}
-		}
+		return LocalStore.get('update-notification.ignored-updates') || {}
 	}
 
 	latest () {
@@ -36,7 +32,7 @@ class UpdateNotification
 
 		ignoredUpdates[host] = this.latest().version
 
-		localStorage.setItem('update-notification.ignored-updates', JSON.stringify(ignoredUpdates))
+		LocalStore.set('update-notification.ignored-updates', ignoredUpdates)
 	}
 
 	versionCompare (left, right) {

--- a/Clockwork Chrome/assets/javascripts/update-notification.js
+++ b/Clockwork Chrome/assets/javascripts/update-notification.js
@@ -6,7 +6,7 @@ class UpdateNotification
 
 	latest () {
 		return {
-			version: '3.1.1',
+			version: '3.1.2',
 			url: 'https://underground.works/blog/clockwork-3.1-released-with-editor-links-and-better-exceptions'
 		}
 	}


### PR DESCRIPTION
- adds localStorage wrapper with fallback to a temporary in-memory store when localStorage is not available
- localStorage might not be available due to browser settings (eg. "block third-party cookies" in Chrome)
- bug report https://github.com/itsgoingd/clockwork-chrome/issues/72